### PR TITLE
Add agentVersion field in agent to give applications the possiblity to describe the version of the agent

### DIFF
--- a/vrpc/VrpcAgent.js
+++ b/vrpc/VrpcAgent.js
@@ -135,10 +135,7 @@ class VrpcAgent extends EventEmitter {
       rejectUnauthorized: false,
       will: {
         topic: `${this._baseTopic}/__agentInfo__`,
-        payload: JSON.stringify({
-          status: 'offline',
-          hostname: os.hostname()
-        }),
+        payload: this._createAgentInfoPayload({ status: 'offline' }),
         qos: this._qos,
         retain: true
       }
@@ -172,10 +169,7 @@ class VrpcAgent extends EventEmitter {
       const agentTopic = `${this._baseTopic}/__agentInfo__`
       this._mqttPublish(
         agentTopic,
-        JSON.stringify({
-          status: 'offline',
-          hostname: os.hostname()
-        }),
+        this._createAgentInfoPayload({ status: 'offline' }),
         { retain: true }
       )
       if (unregister) {
@@ -194,6 +188,13 @@ class VrpcAgent extends EventEmitter {
         `Problem during disconnecting agent: ${err.message}`
       )
     }
+  }
+
+  _createAgentInfoPayload ({ status }) {
+    return JSON.stringify({
+      status,
+      hostname: os.hostname()
+    })
   }
 
   async _clearPersistedSession () {
@@ -314,10 +315,7 @@ class VrpcAgent extends EventEmitter {
   _publishAgentInfoMessage () {
     this._mqttPublish(
       `${this._baseTopic}/__agentInfo__`,
-      JSON.stringify({
-        status: 'online',
-        hostname: os.hostname()
-      }),
+      this._createAgentInfoPayload({ status: 'online' }),
       { retain: true }
     )
   }

--- a/vrpc/VrpcAgent.js
+++ b/vrpc/VrpcAgent.js
@@ -64,6 +64,10 @@ class VrpcAgent extends EventEmitter {
         action: 'store_true'
       }
     )
+    parser.addArgument(
+      ['-A', '--agentVersion'],
+      { help: 'Agent version. May be checked on the remote side for compatibility checks.', required: false }
+    )
     const args = parser.parseArgs()
     return new VrpcAgent(args)
   }
@@ -89,7 +93,8 @@ class VrpcAgent extends EventEmitter {
     token,
     broker = 'mqtts://vrpc.io:8883',
     log = 'console',
-    bestEffort = false
+    bestEffort = false,
+    agentVersion = ''
   } = {}
   ) {
     super()
@@ -100,6 +105,7 @@ class VrpcAgent extends EventEmitter {
     this._domain = domain
     this._broker = broker
     this._qos = bestEffort ? 0 : 1
+    this._agentVersion = agentVersion
     this._isReconnect = false
     if (log === 'console') {
       this._log = console
@@ -193,7 +199,8 @@ class VrpcAgent extends EventEmitter {
   _createAgentInfoPayload ({ status }) {
     return JSON.stringify({
       status,
-      hostname: os.hostname()
+      hostname: os.hostname(),
+      agentVersion: this._agentVersion
     })
   }
 

--- a/vrpc/VrpcRemote.js
+++ b/vrpc/VrpcRemote.js
@@ -162,11 +162,12 @@ class VrpcRemote extends EventEmitter {
       const [domain, agent, klass, instance] = tokens
       // AgentInfo message
       if (klass === '__agentInfo__') {
-        const { status, hostname } = JSON.parse(message.toString())
+        const { status, hostname, agentVersion } = JSON.parse(message.toString())
         this._createIfNotExist(domain, agent)
         this._domains[domain].agents[agent].status = status
         this._domains[domain].agents[agent].hostname = hostname
-        this.emit('agent', { domain, agent, status, hostname })
+        this._domains[domain].agents[agent].agentVersion = agentVersion
+        this.emit('agent', { domain, agent, status, hostname, agentVersion })
       // ClassInfo message
       } else if (instance === '__classInfo__') {
         // Json properties: { className, instances, memberFunctions, staticFunctions }


### PR DESCRIPTION
As discussed in our downstream application, we want to implement the use-case where the local application might have been updated to a newer version, but an Agent is  still around and trying to connect but has an older version. In order to detect this on an application level, the Agent should specify some `agentVersion` which can then be checked in the application in the `agent` event listener.