### PR TITLE
Extend the Agent to emit events if the mqtt connection emits some events

### DIFF
--- a/vrpc/VrpcAgent.js
+++ b/vrpc/VrpcAgent.js
@@ -3,8 +3,23 @@ const mqtt = require('mqtt')
 const crypto = require('crypto')
 const { ArgumentParser } = require('argparse')
 const VrpcAdapter = require('./VrpcAdapter')
+const EventEmitter = require('events')
 
-class VrpcAgent {
+/**
+ * Make code available to remote users over VRPC.
+ *
+ * This class provides the following events that are originally emitted from the
+ * internal MQTT client:
+ *
+ * - connect: Emitted on successful (re)connection
+ * - reconnect: Emitted when a reconnect starts.
+ * - error: Emitted when the client cannot connect (i.e. connack rc != 0) or
+ *   when a parsing error occurs.
+ * - offline: Emitted when the client goes offline.
+ * - close: Emitted after a disconnection.
+ *
+ */
+class VrpcAgent extends EventEmitter {
 
   static fromCommandline () {
     const parser = new ArgumentParser({
@@ -57,6 +72,7 @@ class VrpcAgent {
     bestEffort = false
   } = {}
   ) {
+    super()
     this._username = username
     this._password = password
     this._token = token
@@ -117,6 +133,8 @@ class VrpcAgent {
     this._client.on('reconnect', this._handleReconnect.bind(this))
     this._client.on('error', this._handleError.bind(this))
     this._client.on('message', this._handleMessage.bind(this))
+    this._client.on('close', this._handleClose.bind(this))
+    this._client.on('offline', this._handleOffline.bind(this))
     return this._ensureConnected()
   }
 
@@ -211,6 +229,8 @@ class VrpcAgent {
     this._log.info('[OK]')
     if (this._isReconnect) {
       this._publishAgentInfoMessage()
+      this.emit('connect')
+      this._isReconnect = false
       return
     }
     try {
@@ -230,6 +250,7 @@ class VrpcAgent {
     classes.forEach(className => {
       this._publishClassInfoMessage(className)
     })
+    this.emit('connect')
   }
 
   _publishAgentInfoMessage () {
@@ -483,10 +504,20 @@ class VrpcAgent {
   _handleReconnect () {
     this._isReconnect = true
     this._log.warn(`Reconnecting to ${this._broker}`)
+    this.emit('reconnect')
   }
 
   _handleError (err) {
     this._log.error(`MQTT triggered error: ${err.message}`)
+    this.emit('error', err)
+  }
+
+  _handleClose () {
+    this.emit('close')
+  }
+
+  _handleOffline () {
+    this.emit('offline')
   }
 }
 module.exports = VrpcAgent


### PR DESCRIPTION
As discussed in our downstream application, we want to implement the use-case where the local application might have been updated to a newer version, but an Agent is still around and trying to re-connect to the updated version. In order to be able to react on the Agent side about the situation when the transport-level reconnection is successful, but need to do version checking on the application level, we first need to register an event listener to the actual (re)connection event.

So this PR proposes to route all relevant events from the MQTT client also to interested listeners.

The mqtt client's event list is here: https://github.com/mqttjs/MQTT.js#client  (scroll down a bit) and we just copy the events from there.